### PR TITLE
Ensure the packrat env is used to build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ help:
 	@echo "make (env|test|unittest|build)"
 
 env:
-	Rscript -e "options(repos = \"http://cran.r-project.org/\"); packrat::init(); install.packages(\"knitr\")"
+	Rscript -e "options(repos = \"http://cran.r-project.org/\"); packrat::init();"
 
 test:
 	Rscript -e "devtools::document()"

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ unittest:
 
 build:
 	Rscript -e "devtools::document()"
-	R CMD build .
+	Rscript -e "devtools::build('.')"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ help:
 	@echo "make (env|test|unittest|build)"
 
 env:
-	Rscript -e "options(repos = \"http://cran.r-project.org/\"); packrat::init()"
+	Rscript -e "options(repos = \"http://cran.r-project.org/\"); packrat::init(); install.packages(\"knitr\")"
 
 test:
 	Rscript -e "devtools::document()"


### PR DESCRIPTION
Ensure we use packrat environment to create the package, otherwise it can't find knitr.