### PR TITLE
Added interactive option to plot to use plotly or ggplot2 (default)

### DIFF
--- a/R/Tendril.plot.R
+++ b/R/Tendril.plot.R
@@ -44,19 +44,32 @@
 #' print(res)
 #' @export
 
-plot.Tendril <- function(x, type = c("basic","permutations","percentile")[1], coloring = "Terms", ...){
+plot.Tendril <- function(
+  x,
+  type = c("basic","permutations","percentile")[1],
+  coloring = "Terms",
+  engine = c("ggplot2", "plotly")[1],
+  ...){
 
-  if (type == "basic"){
-    p<-plotbasic(x, coloring=coloring, ...)
-  }
-  else if (type == "permutations"){
-    p<-plotpermutation(x)
-  }
-  else if (type == "percentile"){
-    p<-plotpercentile(x)
-  }
-  else {
-    stop("Invalid type. Must be one of the following: basic, permutations or percentile")
+  if (engine == "ggplot2") {
+    if (type == "basic"){
+      p <- ggplot2_plotbasic(x, coloring=coloring, ...)
+    }
+    else if (type == "permutations"){
+      p<-plotpermutation(x)
+    }
+    else if (type == "percentile"){
+      p<-plotpercentile(x)
+    }
+    else {
+      stop("Invalid type. Must be one of the following: basic, permutations or percentile")
+    }
+  } else if (engine == "plotly") {
+    if (type == "basic"){
+      p <- plotly_plotbasic(x, coloring=coloring, ...)
+    }
+  } else {
+    stop(paste("Invalid engine", engine))
   }
 
   return(p)

--- a/R/Tendril.plot.R
+++ b/R/Tendril.plot.R
@@ -15,6 +15,9 @@
 #' "OR" - Odds Ratio;
 #' "FDR.tot" - P-values adjusted using the False discovery rate method for all tendrils; and
 #' "TermsCount" - Total number of events for that specific type of event
+#' @param interactive Specifies if the plot must be interactive or not.
+#' If interactive == TRUE, plotly will be used to render the plot. Otherwise,
+#' (default) the plot will be rendered as a static image using ggplot2.
 #' @param ... Unused arguments
 #' @details
 #' If saving the results of the function to a variable, this will be of class tendril
@@ -48,10 +51,10 @@ plot.Tendril <- function(
   x,
   type = c("basic","permutations","percentile")[1],
   coloring = "Terms",
-  engine = c("ggplot2", "plotly")[1],
+  interactive = FALSE,
   ...){
 
-  if (engine == "ggplot2") {
+  if (!interactive) {
     if (type == "basic"){
       p <- ggplot2_plotbasic(x, coloring=coloring, ...)
     }
@@ -64,15 +67,13 @@ plot.Tendril <- function(
     else {
       stop("Invalid type. Must be one of the following: basic, permutations or percentile")
     }
-  } else if (engine == "plotly") {
+  } else {
     if (type == "basic"){
       p <- plotly_plotbasic(x, coloring=coloring, ...)
     } else {
       stop("Invalid type. Must be one of the following: basic")
     }
 
-  } else {
-    stop(paste("Invalid engine", engine))
   }
 
   return(p)

--- a/R/Tendril.plot.R
+++ b/R/Tendril.plot.R
@@ -67,7 +67,10 @@ plot.Tendril <- function(
   } else if (engine == "plotly") {
     if (type == "basic"){
       p <- plotly_plotbasic(x, coloring=coloring, ...)
+    } else {
+      stop("Invalid type. Must be one of the following: basic")
     }
+
   } else {
     stop(paste("Invalid engine", engine))
   }

--- a/R/plot.interactive.R
+++ b/R/plot.interactive.R
@@ -1,16 +1,19 @@
-plot.interactive <- function(tendril, opacity=0.5) {
+plotly_plotbasic <- function(tendril, coloring, opacity=0.5) {
   `%>%` <- magrittr::`%>%`
-  cc= tendril$data[["p.adj"]]
 
-  cc.10 <- log10(cc)
-  cc.10[cc.10<(-3)] <- -3
+  cc= tendril$data[[coloring]]
+
+  if(coloring %in% c("p", "p.adj", "fish")) {
+    cc <- log10(cc)
+    cc[cc<(-3)] <- -3
+  }
   palette <- tendril_palette()
 
   p <- tendril$data %>%
     dplyr::group_by(Terms) %>%
     plotly::plot_ly(x=~x, y=~y, width = 700, height = 700,
             mode = "lines+markers", type = "scatter",
-            marker = list(size=~TermsCount/100, opacity=opacity), color = ~cc.10,
+            marker = list(size=~TermsCount/100, opacity=opacity), color = ~cc,
             colors = palette$grpalette,
             line = list(color = "lightgrey"),
             text = ~paste("Term: ", Terms, '<br>Start day:', StartDay, '<br>p.adjusted:', round(p.adj, 4)),

--- a/R/plotbasic.R
+++ b/R/plotbasic.R
@@ -1,5 +1,5 @@
 ## Tendril plot, adjusted with darker border  ##
-plotbasic <- function(x, coloring = "Terms") {
+ggplot2_plotbasic <- function(x, coloring = "Terms") {
   plotdata=data.frame(x= x$data$x,
                       y= x$data$y,
                       Terms= x$data$Terms

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Unfortunately Mojave does not ship with it.
 
 # Changelog
 
+- Version git master
+    - #41 Added interactive option to plot using plotly or ggplot2
+
 - Version 0.7 (1 Oct 2019)
     - First public release
 


### PR DESCRIPTION
This PR adds an option engine to plot() to decide how to render the tendril plot. The default is to render an image with ggplot2. using "plotly" as an engine generates an interactive plot.

@Karpefors this needs an active review.
